### PR TITLE
Update NuGet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ dotnet pack -c Release
 Get it on [NuGet][1].
 
 
-[1]: https://www.nuget.org/packages/Remora.Results.Abstractions/
+[1]: https://www.nuget.org/packages/Remora.Results/


### PR DESCRIPTION
The readme currently points to the old nuget repo. This fixes that:
```diff
- [1]: https://www.nuget.org/packages/Remora.Results.Abstractions/
+ [1]: https://www.nuget.org/packages/Remora.Results/
```