### PR TITLE
Bump version number

### DIFF
--- a/Remora.Results/Remora.Results.csproj
+++ b/Remora.Results/Remora.Results.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>7.2.3</VersionPrefix>
+        <VersionPrefix>7.3.0</VersionPrefix>
         <Description>
             A basic implementation of a descriptive algebraic data type for C#.
         </Description>


### PR DESCRIPTION
Version 7.3.0 adds support for Net641. Bumping minor version as it should be backwards-compatible but this is not a simple bug fix.

Fixes #9