### PR TITLE
Add SuccessfulResult static property

### DIFF
--- a/Remora.Results/Result.cs
+++ b/Remora.Results/Result.cs
@@ -43,6 +43,20 @@ public readonly struct Result : IResult
     public IResultError? Error { get; }
 
     /// <summary>
+    /// Gets a successful result.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property returns a result whose <see cref="Error"/> property is set to null, therefore <see cref="IsSuccess"/> returns true.
+    /// The <see cref="Inner"/> property is also set to null.
+    /// </para>
+    /// <para>
+    /// This is an equivalent of <see cref="FromSuccess"/>.
+    /// </para>
+    /// </remarks>
+    public static Result SuccessfulResult => FromSuccess();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Result"/> struct.
     /// </summary>
     /// <param name="error">The error, if any.</param>

--- a/Remora.Results/Result.cs
+++ b/Remora.Results/Result.cs
@@ -32,6 +32,17 @@ namespace Remora.Results;
 [PublicAPI]
 public readonly struct Result : IResult
 {
+    /// <summary>
+    /// Gets a successful result.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property returns a result whose <see cref="Error"/> property is set to null, therefore <see cref="IsSuccess"/> returns true.
+    /// The <see cref="Inner"/> property is also set to null.
+    /// </para>
+    /// </remarks>
+    public static IResult SuccessfulResult { get; } = FromSuccess();
+
     /// <inheritdoc />
     [MemberNotNullWhen(false, nameof(Error))]
     public bool IsSuccess => this.Error is null;
@@ -41,20 +52,6 @@ public readonly struct Result : IResult
 
     /// <inheritdoc />
     public IResultError? Error { get; }
-
-    /// <summary>
-    /// Gets a successful result.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This property returns a result whose <see cref="Error"/> property is set to null, therefore <see cref="IsSuccess"/> returns true.
-    /// The <see cref="Inner"/> property is also set to null.
-    /// </para>
-    /// <para>
-    /// This is an equivalent of <see cref="FromSuccess"/>.
-    /// </para>
-    /// </remarks>
-    public static Result SuccessfulResult => FromSuccess();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Result"/> struct.

--- a/Remora.Results/Result.cs
+++ b/Remora.Results/Result.cs
@@ -35,7 +35,7 @@ public readonly struct Result : IResult
     /// <summary>
     /// Gets a successful result.
     /// </summary>
-    public static Result Success => FromSuccess();
+    public static Result Success { get; } = FromSuccess();
 
     /// <summary>
     /// Gets a successful result.
@@ -185,7 +185,7 @@ public readonly struct Result<TEntity> : IResult<TEntity>
     /// <summary>
     /// Gets a successful result.
     /// </summary>
-    public static Result<TEntity> Success => new(default, default, default);
+    public static Result<TEntity> Success { get; } = new(default, default, default);
 
     /// <summary>
     /// Gets a successful result.

--- a/Remora.Results/Result.cs
+++ b/Remora.Results/Result.cs
@@ -35,13 +35,15 @@ public readonly struct Result : IResult
     /// <summary>
     /// Gets a successful result.
     /// </summary>
+    public static Result Success => FromSuccess();
+
+    /// <summary>
+    /// Gets a successful result.
+    /// </summary>
     /// <remarks>
-    /// <para>
-    /// This property returns a result whose <see cref="Error"/> property is set to null, therefore <see cref="IsSuccess"/> returns true.
-    /// The <see cref="Inner"/> property is also set to null.
-    /// </para>
+    /// The returned instance is a boxed singleton.
     /// </remarks>
-    public static IResult SuccessfulResult { get; } = FromSuccess();
+    public static IResult BoxedSuccess { get; } = FromSuccess();
 
     /// <inheritdoc />
     [MemberNotNullWhen(false, nameof(Error))]
@@ -180,6 +182,19 @@ public readonly struct Result : IResult
 [PublicAPI]
 public readonly struct Result<TEntity> : IResult<TEntity>
 {
+    /// <summary>
+    /// Gets a successful result.
+    /// </summary>
+    public static Result<TEntity> Success => new(default, default, default);
+
+    /// <summary>
+    /// Gets a successful result.
+    /// </summary>
+    /// <remarks>
+    /// The returned instance is a boxed singleton.
+    /// </remarks>
+    public static IResult BoxedSuccess { get; } = new Result<TEntity>(default, default, default);
+
     /// <summary>
     /// Gets the entity returned by the result.
     /// </summary>

--- a/Tests/Remora.Results.Tests/ResultOfTTests.cs
+++ b/Tests/Remora.Results.Tests/ResultOfTTests.cs
@@ -599,4 +599,58 @@ public static class ResultOfTTests
             Assert.IsType<ExceptionError>(result.Error);
         }
     }
+
+    /// <summary>
+    /// Tests the <see cref="Result.Success"/> property.
+    /// </summary>
+    public class Success
+    {
+        /// <summary>
+        /// Tests whether <see cref="Result.Success"/> returns a successful result.
+        /// </summary>
+        [Fact]
+        public void ReturnsASuccessfulResult()
+        {
+            var successful = Result<int>.Success;
+            Assert.True(successful.IsSuccess);
+        }
+
+        /// <summary>
+        /// Tests whether <see cref="Result.Success"/> returns equal instances.
+        /// </summary>
+        [Fact]
+        public void ReturnsEqualInstances()
+        {
+            var successful1 = Result<int>.Success;
+            var successful2 = Result<int>.Success;
+            Assert.Equal(successful1, successful2);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="Result.BoxedSuccess"/> property.
+    /// </summary>
+    public class BoxedSuccess
+    {
+        /// <summary>
+        /// Tests whether <see cref="Result.BoxedSuccess"/> returns a successful result.
+        /// </summary>
+        [Fact]
+        public void ReturnsASuccessfulResult()
+        {
+            var successful = Result<int>.BoxedSuccess;
+            Assert.True(successful.IsSuccess);
+        }
+
+        /// <summary>
+        /// Tests whether <see cref="Result.BoxedSuccess"/> always returns the same instance for the same T.
+        /// </summary>
+        [Fact]
+        public void ReturnsTheSameInstanceForTheSameT()
+        {
+            var successful1 = Result<int>.BoxedSuccess;
+            var successful2 = Result<int>.BoxedSuccess;
+            Assert.Same(successful1, successful2);
+        }
+    }
 }

--- a/Tests/Remora.Results.Tests/ResultOfTTests.cs
+++ b/Tests/Remora.Results.Tests/ResultOfTTests.cs
@@ -601,12 +601,12 @@ public static class ResultOfTTests
     }
 
     /// <summary>
-    /// Tests the <see cref="Result.Success"/> property.
+    /// Tests the <see cref="Result{T}.Success"/> property.
     /// </summary>
     public class Success
     {
         /// <summary>
-        /// Tests whether <see cref="Result.Success"/> returns a successful result.
+        /// Tests whether <see cref="Result{T}.Success"/> returns a successful result.
         /// </summary>
         [Fact]
         public void ReturnsASuccessfulResult()
@@ -616,7 +616,7 @@ public static class ResultOfTTests
         }
 
         /// <summary>
-        /// Tests whether <see cref="Result.Success"/> returns equal instances.
+        /// Tests whether <see cref="Result{T}.Success"/> returns equal instances.
         /// </summary>
         [Fact]
         public void ReturnsEqualInstances()
@@ -628,12 +628,12 @@ public static class ResultOfTTests
     }
 
     /// <summary>
-    /// Tests the <see cref="Result.BoxedSuccess"/> property.
+    /// Tests the <see cref="Result{T}.BoxedSuccess"/> property.
     /// </summary>
     public class BoxedSuccess
     {
         /// <summary>
-        /// Tests whether <see cref="Result.BoxedSuccess"/> returns a successful result.
+        /// Tests whether <see cref="Result{T}.BoxedSuccess"/> returns a successful result.
         /// </summary>
         [Fact]
         public void ReturnsASuccessfulResult()
@@ -643,7 +643,7 @@ public static class ResultOfTTests
         }
 
         /// <summary>
-        /// Tests whether <see cref="Result.BoxedSuccess"/> always returns the same instance for the same T.
+        /// Tests whether <see cref="Result{T}.BoxedSuccess"/> always returns the same instance for the same T.
         /// </summary>
         [Fact]
         public void ReturnsTheSameInstanceForTheSameT()

--- a/Tests/Remora.Results.Tests/ResultTests.cs
+++ b/Tests/Remora.Results.Tests/ResultTests.cs
@@ -416,14 +416,14 @@ public static class ResultTests
         }
 
         /// <summary>
-        /// Tests whether <see cref="Result.SuccessfulResult"/> always returns equal instances.
+        /// Tests whether <see cref="Result.SuccessfulResult"/> always returns same instance.
         /// </summary>
         [Fact]
-        public void ReturnsEqualInstances()
+        public void ReturnsSameInstance()
         {
             var successful1 = Result.SuccessfulResult;
             var successful2 = Result.SuccessfulResult;
-            Assert.Equal(successful1, successful2);
+            Assert.Same(successful1, successful2);
         }
     }
 }

--- a/Tests/Remora.Results.Tests/ResultTests.cs
+++ b/Tests/Remora.Results.Tests/ResultTests.cs
@@ -391,38 +391,55 @@ public static class ResultTests
     }
 
     /// <summary>
-    /// Tests the <see cref="Result.SuccessfulResult"/> property.
+    /// Tests the <see cref="Result.Success"/> property.
     /// </summary>
-    public class SuccessfulResult
+    public class Success
     {
         /// <summary>
-        /// Tests whether <see cref="Result.SuccessfulResult"/> returns a successful result.
+        /// Tests whether <see cref="Result.Success"/> returns a successful result.
         /// </summary>
         [Fact]
         public void ReturnsASuccessfulResult()
         {
-            var successful = Result.SuccessfulResult;
+            var successful = Result.Success;
             Assert.True(successful.IsSuccess);
         }
 
         /// <summary>
-        /// Tests whether <see cref="Result.SuccessfulResult"/> returns a result whose inner property is null.
+        /// Tests whether <see cref="Result.Success"/> returns equal instances.
         /// </summary>
         [Fact]
-        public void ReturnsAResultWhoseInnerPropertyIsNull()
+        public void ReturnsEqualInstances()
         {
-            var successful = Result.SuccessfulResult;
-            Assert.Null(successful.Inner);
+            var successful1 = Result.Success;
+            var successful2 = Result.Success;
+            Assert.Equal(successful1, successful2);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="Result.BoxedSuccess"/> property.
+    /// </summary>
+    public class BoxedSuccess
+    {
+        /// <summary>
+        /// Tests whether <see cref="Result.BoxedSuccess"/> returns a successful result.
+        /// </summary>
+        [Fact]
+        public void ReturnsASuccessfulResult()
+        {
+            var successful = Result.BoxedSuccess;
+            Assert.True(successful.IsSuccess);
         }
 
         /// <summary>
-        /// Tests whether <see cref="Result.SuccessfulResult"/> always returns same instance.
+        /// Tests whether <see cref="Result.BoxedSuccess"/> always returns the same instance.
         /// </summary>
         [Fact]
-        public void ReturnsSameInstance()
+        public void ReturnsTheSameInstance()
         {
-            var successful1 = Result.SuccessfulResult;
-            var successful2 = Result.SuccessfulResult;
+            var successful1 = Result.BoxedSuccess;
+            var successful2 = Result.BoxedSuccess;
             Assert.Same(successful1, successful2);
         }
     }

--- a/Tests/Remora.Results.Tests/ResultTests.cs
+++ b/Tests/Remora.Results.Tests/ResultTests.cs
@@ -389,4 +389,41 @@ public static class ResultTests
             Assert.IsType<ExceptionError>(result.Error);
         }
     }
+
+    /// <summary>
+    /// Tests the <see cref="Result.SuccessfulResult"/> property.
+    /// </summary>
+    public class SuccessfulResult
+    {
+        /// <summary>
+        /// Tests whether <see cref="Result.SuccessfulResult"/> returns a successful result.
+        /// </summary>
+        [Fact]
+        public void ReturnsASuccessfulResult()
+        {
+            var successful = Result.SuccessfulResult;
+            Assert.True(successful.IsSuccess);
+        }
+
+        /// <summary>
+        /// Tests whether <see cref="Result.SuccessfulResult"/> returns a result whose inner property is null.
+        /// </summary>
+        [Fact]
+        public void ReturnsAResultWhoseInnerPropertyIsNull()
+        {
+            var successful = Result.SuccessfulResult;
+            Assert.Null(successful.Inner);
+        }
+
+        /// <summary>
+        /// Tests whether <see cref="Result.SuccessfulResult"/> always returns equal instances.
+        /// </summary>
+        [Fact]
+        public void ReturnsEqualInstances()
+        {
+            var successful1 = Result.SuccessfulResult;
+            var successful2 = Result.SuccessfulResult;
+            Assert.Equal(successful1, successful2);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a `SuccessfulResult` static property to `Result` much like `ValueTask`'s / `Task`'s `CompletedTask` property with a cached boxed instance of a successful result.