### PR TITLE
Fix typo in `dotnet.yml` workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
           keep: 4
           names: |
             Remora.Results
-            Remora.Results.Analuyzers
+            Remora.Results.Analyzers
 
       - name: Push to GitHub Feed
         run: |


### PR DESCRIPTION
Fixes a typo in the package name for `Remora.Results.Analyzers` in the `dotnet.yml` GitHub workflow.